### PR TITLE
Compilation failure in coap_io.c when NDEBUG=1

### DIFF
--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -54,6 +54,7 @@ typedef SOCKET coap_socket_t;
 #include "debug.h"
 #include "mem.h"
 #include "coap_io.h"
+#include "pdu.h"
 
 #if !defined(WITH_LWIP) && !defined(WITH_CONTIKI)
 struct coap_packet_t {


### PR DESCRIPTION
Currenlty building libcoap with NDEBUG=1 causes below compilation error :
"coap_io.c: error : 'COAP_MAX_PDU_SIZE': undeclared identifier".
<pdu.h> file which contains the definition of 'COAP_MAX_PDU_SIZE' is
included only when NDEBUG=0 (inside <debug.h>).
Building iotivity with RELEASE=1 and TEST=1, fails because of above
reason. Proposed fix is to include <pdu.h> inside coap_io.c.
