### PR TITLE
Removing W4 warnings

### DIFF
--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -400,11 +400,9 @@ int coap_handle_message(coap_context_t *ctx,
  * @param pdu  The message that initiated the transaction.
  * @param id   Set to the new id.
  */
-#if defined(WITH_POSIX) || defined(WITH_LWIP) || defined(WITH_CONTIKI)
 void coap_transaction_id(const coap_address_t *peer,
                          const coap_pdu_t *pdu,
                          coap_tid_t *id);
-#endif
 
 /**
  * This function removes the element with given @p id from the list given list.

--- a/include/coap/pdu.h
+++ b/include/coap/pdu.h
@@ -300,7 +300,7 @@ typedef struct {
  */
 
 typedef struct {
-  size_t max_size;          /**< allocated storage for options and data */
+  size_t max_size;            /**< allocated storage for options and data */
   union {
     coap_hdr_t *hdr;          /**< Address of the first byte of the CoAP message.
                                *   This may or may not equal (coap_hdr_t*)(pdu+1)

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -323,12 +323,10 @@ coap_network_send(struct coap_context_t *context UNUSED_PARAM,
     struct in6_pktinfo *pktinfo;
 
 #ifdef WSA_CMSG_SPACE
-#pragma warning( push )
-#pragma warning( disable : 4116 )
     /* Warning C4116 "unnamed type definition in parantheses" is harmless in
      * this case and the unnamed type is part of a system header macro. */
+#pragma warning( suppress : 4116 )
     mhdr.Control.len = CMSG_SPACE(sizeof(struct in6_pktinfo));
-#pragma warning( pop )
 #else
     mhdr.msg_controllen = CMSG_SPACE(sizeof(struct in6_pktinfo));
 #endif
@@ -361,12 +359,10 @@ coap_network_send(struct coap_context_t *context UNUSED_PARAM,
     struct in_pktinfo *pktinfo;
 
 #ifdef WSA_CMSG_SPACE
-#pragma warning( push )
-#pragma warning( disable : 4116 )
     /* Warning C4116 "unnamed type definition in parantheses" is harmless in
      * this case and the unnamed type is part of a system header macro. */
+#pragma warning( suppress : 4116 )
     mhdr.Control.len = CMSG_SPACE(sizeof(struct in_pktinfo));
-#pragma warning( pop )
 #else
     mhdr.msg_controllen = CMSG_SPACE(sizeof(struct in_pktinfo));
 #endif

--- a/src/coap_time.c
+++ b/src/coap_time.c
@@ -35,6 +35,7 @@ static coap_tick_t coap_clock_offset = 0;
 #ifdef HAVE_WINSOCK2_H
 static int
 gettimeofday(struct timeval *tp, TIME_ZONE_INFORMATION *tzp) {
+  (void)tzp;
   static const uint64_t EPOCH = ((uint64_t) 116444736000000000ULL);
 
   SYSTEMTIME system_time;
@@ -76,7 +77,7 @@ coap_clock_init(void) {
 
 void
 coap_ticks(coap_tick_t *t) {
-  unsigned long tmp;
+  coap_tick_t tmp;
 
 #ifdef COAP_CLOCK
   struct timespec tv;

--- a/src/encode.c
+++ b/src/encode.c
@@ -18,7 +18,8 @@
 #endif
 
 /* Carsten suggested this when fls() is not available: */
-coap_fls(unsigned int i) {
+#ifndef HAVE_FLS
+int coap_fls(unsigned int i) {
   return coap_flsll(i);
 }
 #endif

--- a/src/net.c
+++ b/src/net.c
@@ -1260,8 +1260,7 @@ coap_wellknown_response(coap_context_t *context, coap_pdu_t *request) {
   }
   
   unsigned int new_resp_length = resp->length + COAP_PRINT_OUTPUT_LENGTH(result);
-  if (new_resp_length > USHRT_MAX)
-  {
+  if (new_resp_length > USHRT_MAX) {
       debug("coap_print_wellknown failed - print result too large\n");
       goto error;
   }

--- a/src/net.c
+++ b/src/net.c
@@ -496,19 +496,16 @@ coap_option_check_critical(coap_context_t *ctx,
   return ok;
 }
 
-#if defined(WITH_POSIX) || defined(WITH_LWIP) || defined(WITH_CONTIKI)
 void
 coap_transaction_id(const coap_address_t *peer, const coap_pdu_t *pdu, 
 		    coap_tid_t *id) {
-  (void)peer;
-
   coap_key_t h;
 
   memset(h, 0, sizeof(coap_key_t));
 
   /* Compare the transport address. */
 
-#ifdef WITH_POSIX
+#if defined(WITH_POSIX) || defined(HAVE_WS2TCPIP_H)
   switch (peer->addr.sa.sa_family) {
   case AF_INET:
     coap_hash((const unsigned char *)&peer->addr.sin.sin_port,
@@ -536,7 +533,6 @@ coap_transaction_id(const coap_address_t *peer, const coap_pdu_t *pdu,
 
   *id = (((h[0] << 8) | h[1]) ^ ((h[2] << 8) | h[3])) & INT_MAX;
 }
-#endif
 
 coap_tid_t
 coap_send_ack(coap_context_t *context, 
@@ -1574,6 +1570,8 @@ handle_locally(coap_context_t *context __attribute__ ((unused)),
 handle_locally(coap_context_t *context, coap_queue_t *node) {
 #endif /* GCC */
   /* this function can be used to check if node->pdu is really for us */
+  (void)context;
+  (void)node;
   return 1;
 }
 

--- a/src/resource.c
+++ b/src/resource.c
@@ -284,8 +284,7 @@ coap_print_wellknown(coap_context_t *context, unsigned char *buf, size_t *buflen
   *buflen = written;
   output_length = p - buf;
 
-  if (output_length > COAP_PRINT_STATUS_MAX)
-  {
+  if (output_length > COAP_PRINT_STATUS_MAX) {
     return COAP_PRINT_STATUS_ERROR;
   }
 
@@ -527,8 +526,7 @@ coap_print_link(const coap_resource_t *resource,
 
   output_length = p - buf;
 
-  if (output_length > COAP_PRINT_STATUS_MAX)
-  {
+  if (output_length > COAP_PRINT_STATUS_MAX) {
     return COAP_PRINT_STATUS_ERROR;
   }
 
@@ -692,8 +690,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r) {
 
       if (COAP_INVALID_TID == tid || response->hdr->type != COAP_MESSAGE_CON)
 	coap_delete_pdu(response);
-      if (COAP_INVALID_TID == tid)
-      {
+      if (COAP_INVALID_TID == tid) {
 	debug("coap_check_notify: sending failed, resource stays partially dirty\n");
         obs->dirty = 1;
         r->partiallydirty = 1;


### PR DESCRIPTION
A change removing the remaining W4 warnings from libcoap.