### PR TITLE
Fix for where WITH_TCP is defined, WITH_WS is not.

### DIFF
--- a/include/coap/pdu.h
+++ b/include/coap/pdu.h
@@ -621,7 +621,7 @@ int coap_add_token2(coap_pdu_t *pdu, size_t len, const unsigned char *data,
  */
 int coap_add_token_to_empty_message(coap_pdu_t *pdu, size_t len, const unsigned char *data,
                                     coap_transport_t transport);
-    
+
 /**
  * Get token from coap header
  *

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -950,6 +950,7 @@ coap_pdu_parse2(unsigned char *data, size_t length, coap_pdu_t *pdu,
   switch (transport) {
     case COAP_UDP:
       break;
+#if defined(WITH_TCP)
     case COAP_TCP:
       for (size_t i = 0 ; i < headerSize ; i++) {
         pdu->transport_hdr->tcp.header_data[i] = data[i];
@@ -984,6 +985,8 @@ coap_pdu_parse2(unsigned char *data, size_t length, coap_pdu_t *pdu,
       opt = ((unsigned char *) &(pdu->transport_hdr->tcp_32bit)) +
               headerSize + tokenLength;
       break;
+#endif
+#if defined(WITH_WS)
     case COAP_WS:
       for (size_t i = 0 ; i < headerSize ; i++) {
         pdu->transport_hdr->ws.header_data[i] = data[i];
@@ -993,6 +996,7 @@ coap_pdu_parse2(unsigned char *data, size_t length, coap_pdu_t *pdu,
       opt = ((unsigned char *) &(pdu->transport_hdr->ws)) +
               headerSize + tokenLength;
       break;
+#endif
     default:
       printf("it has wrong type\n");
   }


### PR DESCRIPTION
The function coap_pdu_parse2() as changed by iotivity patches has a
block of code bracketed by

  #if defined(WITH_TCP) || defined(WITH_WS)

the problem is this block contains a reference to a structure member
that is defined only if WITH_WS is defined, and it is possible to build
this code in iotivity in the presence of WITH_TCP and the absence of
WITH_WS. Whether that should ever happen is a separate question; the
change keeps these two conditions separate so this can be used in the
iotivity CI system which does build some targets in the way noted.

Signed-off-by: Mats Wichmann <mats@linux.com>